### PR TITLE
Ignore some framework ref packags

### DIFF
--- a/BuildCacheSettings.json
+++ b/BuildCacheSettings.json
@@ -11,7 +11,7 @@
     "MaxConcurrentCacheContentOperations": "",
     "LocalCacheRootPath": "",
     "LocalCacheSizeInMegabytes": "",
-    "IgnoredInputPatterns": ".gitignore;/**/microsoft.visualstudioeng.microbuild.plugins.*/**",
+    "IgnoredInputPatterns": ".gitignore;/**/microsoft.visualstudioeng.microbuild.plugins.*/**;/**/microsoft.netcore.app.ref/**",
     "IgnoredOutputPatterns": ";*.assets.cache;*assemblyreference.cache",
     "IdenticalDuplicateOutputPatterns": "**",
     "IgnoreDotNetSdkPatchVersion": "true",

--- a/BuildCacheSettings.json
+++ b/BuildCacheSettings.json
@@ -11,7 +11,7 @@
     "MaxConcurrentCacheContentOperations": "",
     "LocalCacheRootPath": "",
     "LocalCacheSizeInMegabytes": "",
-    "IgnoredInputPatterns": ".gitignore;/**/microsoft.visualstudioeng.microbuild.plugins.*/**;/**/microsoft.netcore.app.ref/**",
+    "IgnoredInputPatterns": ".gitignore;/**/microsoft.visualstudioeng.microbuild.plugins.*/**;/**/microsoft.netcore.app.ref/**;/**/microsoft.netcore.app.host.win-x64/**",
     "IgnoredOutputPatterns": ";*.assets.cache;*assemblyreference.cache",
     "IdenticalDuplicateOutputPatterns": "**",
     "IgnoreDotNetSdkPatchVersion": "true",

--- a/build/cachebuild/cache_build.props
+++ b/build/cachebuild/cache_build.props
@@ -39,7 +39,7 @@
     <MSBuildCacheIgnoreDotNetSdkPatchVersion>true</MSBuildCacheIgnoreDotNetSdkPatchVersion>
 
     <!-- Ignoring MicroBuild PlugIns-->
-    <MSBuildCacheIgnoredInputPatterns>.gitignore;/**/microsoft.visualstudioeng.microbuild.plugins.*/**</MSBuildCacheIgnoredInputPatterns>
+    <MSBuildCacheIgnoredInputPatterns>.gitignore;/**/microsoft.visualstudioeng.microbuild.plugins.*/**;/**/microsoft.netcore.app.ref/**</MSBuildCacheIgnoredInputPatterns>
   </PropertyGroup>
 
   <Import Project="$(Agent_TempDirectory)\Microsoft.MSBuildCache.AzureBlobStorage\build\Microsoft.MSBuildCache.AzureBlobStorage.props" />

--- a/build/cachebuild/cache_build.props
+++ b/build/cachebuild/cache_build.props
@@ -39,7 +39,7 @@
     <MSBuildCacheIgnoreDotNetSdkPatchVersion>true</MSBuildCacheIgnoreDotNetSdkPatchVersion>
 
     <!-- Ignoring MicroBuild PlugIns-->
-    <MSBuildCacheIgnoredInputPatterns>.gitignore;/**/microsoft.visualstudioeng.microbuild.plugins.*/**;/**/microsoft.netcore.app.ref/**</MSBuildCacheIgnoredInputPatterns>
+    <MSBuildCacheIgnoredInputPatterns>.gitignore;/**/microsoft.visualstudioeng.microbuild.plugins.*/**;/**/microsoft.netcore.app.ref/**;/**/microsoft.netcore.app.host.win-x64/**</MSBuildCacheIgnoredInputPatterns>
   </PropertyGroup>
 
   <Import Project="$(Agent_TempDirectory)\Microsoft.MSBuildCache.AzureBlobStorage\build\Microsoft.MSBuildCache.AzureBlobStorage.props" />


### PR DESCRIPTION
This is a workaround until cache plug-in can handle those packages correctly.